### PR TITLE
Added CMake install targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.7.0)
 project(croncpp)
 
+set(CMAKE_CXX_STANDARD 17)
+
 # Include
 include(GNUInstallDirs)
 include(ExternalProject)
@@ -22,3 +24,6 @@ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAM
 install(EXPORT croncppConfig DESTINATION share/croncpp/cmake)
 
 export(TARGETS ${PROJECT_NAME} FILE croncppConfig.cmake)
+
+add_subdirectory(benchmark)
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 include(ExternalProject)
 
 add_library(${PROJECT_NAME} INTERFACE)
-target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,24 @@
 cmake_minimum_required(VERSION 3.7.0)
 project(croncpp)
 
-if(WIN32)
-	message(status "Setting MSVC flags")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc /std:c++latest")
-   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-elseif(APPLE)
-	message(status "Setting Clang flags")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fexceptions -g -Wall")
-else()
-	include_directories(${LIBUUID_INCLUDE_DIR})
-   message(status "Setting GCC flags")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -fexceptions -g -Wall")
-endif()
+# Include
+include(GNUInstallDirs)
+include(ExternalProject)
 
-message(status "** CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+add_library(${PROJECT_NAME} INTERFACE)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
-add_subdirectory(benchmark)
-add_subdirectory(test)
+target_include_directories(${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+install(TARGETS ${PROJECT_NAME} EXPORT croncppConfig
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+install(EXPORT croncppConfig DESTINATION share/croncpp/cmake)
+
+export(TARGETS ${PROJECT_NAME} FILE croncppConfig.cmake)

--- a/include/croncpp.h
+++ b/include/croncpp.h
@@ -709,7 +709,7 @@ namespace cron
       }
    }
 
-   template <typename Traits = cron_standard_traits>
+   template <typename Traits>
    static cronexpr make_cron(std::string_view expr)
    {
       cronexpr cex;

--- a/include/croncpp.h
+++ b/include/croncpp.h
@@ -728,7 +728,7 @@ namespace cron
       }
    }
 
-   template <typename Traits>
+   template <typename Traits = cron_standard_traits>
    static cronexpr make_cron(std::string_view expr)
    {
       cronexpr cex;


### PR DESCRIPTION
I added CMake install target so that a user can:

```bash
mkdir build
cd build
cmake ..
make install
```
Next, you can use:

```cmake
find_package(croncpp REQUIRED)
```
And in the code:

```cpp
#include <croncpp/croncpp.h>
```
