### PR TITLE
Add interface target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: cpp
 compiler: gcc
 dist: trusty
-  
+
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
   - pip install --user cpp-coveralls
 
-install: 
+install:
   - sudo apt-get install -qq g++-8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
   - sudo apt-get install -qq cppcheck
-  
+
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
-  - cmake -H. -BBuild -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PROFILING=ON -Wdev
+  - cmake -H. -BBuild -DCMAKE_BUILD_TYPE=Release -DCRONCPP_BUILD_TESTS=ON -DCRONCPP_ENABLE_PROFILING=ON -Wdev
   - cd Build
-  
+
 script:
   - make -j 2
   - ctest -V -j 2 -C Release
-  - cppcheck --quiet --error-exitcode=1 . 
+  - cppcheck --quiet --error-exitcode=1 .
 
 after_success:
   - coveralls --exclude lib --exclude benchmarks --gcov-options '\-lp'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,57 @@
-cmake_minimum_required(VERSION 3.7.0)
-project(croncpp)
+cmake_minimum_required(VERSION 3.8)
+project(
+  croncpp
+  VERSION 0.0.0
+  LANGUAGES CXX)
+
+add_library(croncpp INTERFACE)
+target_include_directories(
+  croncpp INTERFACE $<INSTALL_INTERFACE:include>
+                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_compile_features(croncpp INTERFACE cxx_std_17)
+add_library(croncpp::croncpp ALIAS croncpp)
+
+install(
+  TARGETS croncpp
+  EXPORT croncpp_targets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/ DESTINATION include)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(croncpp.cmake COMPATIBILITY AnyNewerVersion)
+
+install(
+  EXPORT croncpp_targets
+  FILE croncpp.cmake
+  NAMESPACE croncpp::
+  DESTINATION lib/cmake/croncpp)
+
+add_library(croncpp_options INTERFACE)
+target_compile_features(croncpp_options INTERFACE cxx_std_17)
 
 if(WIN32)
-   message(status "Setting MSVC flags")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc /std:c++latest")
-   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+  target_compile_options(croncpp_options INTERFACE "/EHc")
+  target_compile_definitions(croncpp_options
+                             INTERFACE "-D_SCL_SECURE_NO_WARNINGS")
 elseif(APPLE)
-   message(status "Setting Clang flags")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fexceptions -g -Wall")
+  target_compile_options(croncpp_options INTERFACE "-fexceptions -g -Wall")
 else()
-   message(status "Setting GCC flags")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fexceptions -g -Wall")
-   # enable profiling
-   if(ENABLE_PROFILING)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -g -O0 -fprofile-arcs -ftest-coverage") 
-   endif()
+  target_compile_options(croncpp_options INTERFACE "-fexceptions -g -Wall")
+  # enable profiling
+  if(CRONCPP_ENABLE_PROFILING)
+    target_compile_options(
+      croncpp_options
+      INTERFACE "--coverage -g -O0 -fprofile-arcs -ftest-coverage")
+  endif()
 endif()
 
-message(status "** CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-
-if(BUILD_TESTS)
-    include(CTest)
+if(CRONCPP_BUILD_TESTS)
+  add_subdirectory(test)
 endif()
 
-add_subdirectory(benchmark)
-add_subdirectory(test)
+if(CRONCPP_BUILD_BENCHMARK)
+  add_subdirectory(benchmark)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
 endif()
 
 if(CRONCPP_BUILD_TESTS)
+   enable_testing()
   add_subdirectory(test)
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ init:
 before_build:
   - mkdir build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DBUILD_TESTS=ON -DCMAKE_CXX_FLAGS="%FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
+  - cmake .. -G "%GENERATOR%" -DCRONCPP_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="%FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
 
 build_script:
   - cmake --build . --config Release

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,10 +1,5 @@
-cmake_minimum_required(VERSION 3.7.0)
-project(bench_croncpp)
+set(SOURCES main.cpp)
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
-file(GLOB headers ${CMAKE_SOURCE_DIR}/include/*.h)
-file(GLOB SOURCES "*.cpp" "include/*.cpp")
-
-add_executable(bench_croncpp ${SOURCES} ${headers})
-
+add_executable(bench_croncpp ${SOURCES})
+target_link_libraries(bench_croncpp PRIVATE croncpp croncpp_options)
+target_include_directories(bench_croncpp PRIVATE ${CMAKE_SOURCE_DIR}/catch)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,6 @@ add_executable(test_croncpp ${SOURCES})
 target_link_libraries(test_croncpp PRIVATE croncpp croncpp_options)
 target_include_directories(test_croncpp PRIVATE ${CMAKE_SOURCE_DIR}/catch)
 
-enable_testing()
-
 add_test(NAME "test_croncpp" COMMAND "test_croncpp" "-r compact")
 set_tests_properties("test_croncpp" PROPERTIES PASS_REGULAR_EXPRESSION
                                                "Passed all.*")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,25 +1,14 @@
-cmake_minimum_required(VERSION 3.7.0)
-project(test_croncpp)
+set(SOURCES main.cpp test_oracle.cpp test_standard.cpp)
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_SOURCE_DIR}/catch)
+add_executable(test_croncpp ${SOURCES})
+target_link_libraries(test_croncpp PRIVATE croncpp croncpp_options)
+target_include_directories(test_croncpp PRIVATE ${CMAKE_SOURCE_DIR}/catch)
 
-file(GLOB headers ${CMAKE_SOURCE_DIR}/include/*.h)
-file(GLOB SOURCES "*.cpp" "include/*.cpp")
+enable_testing()
 
-add_executable(test_croncpp ${SOURCES} ${headers})
-
-if(BUILD_TESTS)
-    enable_testing()
-
-    add_test(NAME "test_croncpp" COMMAND "test_croncpp" "-r compact")
-    set_tests_properties("test_croncpp"
-        PROPERTIES
-        PASS_REGULAR_EXPRESSION "Passed all.*")
-    set_tests_properties("test_croncpp"
-        PROPERTIES
-        FAIL_REGULAR_EXPRESSION "Failed \\d+ test cases")
-    set_tests_properties("test_croncpp"
-        PROPERTIES
-        TIMEOUT 120)
-endif()
+add_test(NAME "test_croncpp" COMMAND "test_croncpp" "-r compact")
+set_tests_properties("test_croncpp" PROPERTIES PASS_REGULAR_EXPRESSION
+                                               "Passed all.*")
+set_tests_properties("test_croncpp" PROPERTIES FAIL_REGULAR_EXPRESSION
+                                               "Failed \\d+ test cases")
+set_tests_properties("test_croncpp" PROPERTIES TIMEOUT 120)


### PR DESCRIPTION
I was pulling in your project via CMake's FetchContent module (as opposed to just copying the include file into my source tree). I ran into some issues:
- There was no INTERFACE target to link against, so I would have to sort out the include directory myself.
- The compiler options and definitions were set globally, potentially conflicting with my own project settings.

To address these, I created an interface target that just defines the include directory and specifies the C++17 requirement. I also made another INTERFACE target that defines the compiler options and definitions that the tests and benchmarks can share. This should keep these settings private such that they don't affect any outer project (should someone include your project as a git submodule or using CMake's FetchContent or ExternalProject modules).

I also updated the CI scripts, although I'm not sure if I have made all the necessary changes.