### PR TITLE
Add cron_next_ceil overload to fix subsecond precision issues with time_point conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ catch (cron::bad_cronexpr const & ex)
 }
 ```
 
+A `std::chrono::system_clock::time_point` overload is also available, but because `cron_next()` converts the time point to `time_t` using `to_time_t()`, fractional seconds are truncated.
+If you are working from a known trigger instant and a sub-second drift could move the time point below the exact second, use `cron_next_ceil()` to round up to the next whole second before computing the next occurrence.
+
+```
+try
+{
+   auto cron = cron::make_cron("* 0/5 * * * ?");
+
+   auto now = std::chrono::system_clock::now();
+   auto next = cron::cron_next(cron, now);
+   auto next_ceil = cron::cron_next_ceil(cron, now);
+}
+catch (cron::bad_cronexpr const & ex)
+{
+   std::cerr << ex.what() << '\n';
+}
+```
+
 When you use these functions as shown above you implicitly use the standard supported values for the fields, as described in the first section. However, you can use any other settings. The ones provided with the library are called `cron_standard_traits`, `cron_oracle_traits` and `cron_quartz_traits` (coresponding to the aforementioned settings).
 
 ```

--- a/include/croncpp.h
+++ b/include/croncpp.h
@@ -914,4 +914,18 @@ namespace cron
   static std::chrono::system_clock::time_point cron_next(cronexpr const & cex, std::chrono::system_clock::time_point const & time_point) {
      return std::chrono::system_clock::from_time_t(cron_next<Traits>(cex, std::chrono::system_clock::to_time_t(time_point)));
   }
+
+  template <typename Traits = cron_standard_traits>
+  static std::chrono::system_clock::time_point cron_next_ceil(cronexpr const & cex, std::chrono::system_clock::time_point const & time_point) {
+     // std::chrono::system_clock::to_time_t truncates fractional seconds.
+     // If the input time_point represents a known cron trigger time but is
+     // slightly below that exact second, truncation can move it back one
+     // second and cause cron_next to return the current trigger instead of
+     // the next one.
+     auto tt = std::chrono::system_clock::to_time_t(time_point);
+     if (std::chrono::system_clock::from_time_t(tt) < time_point) {
+        ++tt;
+     }
+     return std::chrono::system_clock::from_time_t(cron_next<Traits>(cex, tt));
+  }
 }

--- a/test/test_standard.cpp
+++ b/test/test_standard.cpp
@@ -65,6 +65,19 @@ void check_cron_conv(CRONCPP_STRING_VIEW expr)
    REQUIRE(to_cronstr(cex).compare(expr) == 0);
 }
 
+TEST_CASE("standard: cron_next_ceil rounds up time_point when subsecond drift is present", "[std]")
+{
+   auto cex = make_cron("0 0 12 * * *");
+   auto base_time = utils::to_tm("2018-08-08 12:00:00");
+   auto tp = std::chrono::system_clock::from_time_t(utils::tm_to_time(base_time)) - std::chrono::milliseconds(50);
+
+   auto next = cron_next(cex, tp);
+   auto next_ceil = cron_next_ceil(cex, tp);
+
+   REQUIRE(std::chrono::system_clock::to_time_t(next) == utils::tm_to_time(base_time));
+   REQUIRE(std::chrono::system_clock::to_time_t(next_ceil) == utils::tm_to_time(utils::to_tm("2018-08-09 12:00:00")));
+}
+
 TEST_CASE("Test simple", "")
 {
    auto cex = make_cron("* * * * * *");


### PR DESCRIPTION
see #38 